### PR TITLE
docs: Add recommended token limits to prevent TPM limits

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -125,11 +125,14 @@ embedding_model = "local"
 # Maximum number of characters in an observation's content
 #max_message_chars = 10000
 
-# Maximum number of input tokens
-#max_input_tokens = 0
+# Maximum number of input tokens (recommended: 20000 to prevent TPM limits)
+#max_input_tokens = 20000
 
 # Maximum number of output tokens
 #max_output_tokens = 0
+
+# Maximum number of characters in messages (recommended: 80000 when using max_input_tokens)
+#max_message_chars = 80000
 
 # Model to use
 model = "gpt-4o"


### PR DESCRIPTION
This PR adds documentation about recommended token limits in the config template to help prevent TPM (Tokens Per Minute) limits.

Changes:
- Added recommended value of 20000 for max_input_tokens
- Added recommended value of 80000 for max_message_chars when using token limits
- Added explanatory comments about these recommendations

To use these limits:
1. Copy config.template.toml to config.toml
2. Uncomment and set the recommended values:
```toml
max_input_tokens = 20000
max_message_chars = 80000
```